### PR TITLE
Fix user ID handling across login and notice creation

### DIFF
--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -59,7 +59,7 @@ router.post('/login', async (req, res) => {
         }
 
         const token = jwt.sign({ userId: user.id, email: user.email }, process.env.JWT_SECRET, { expiresIn: '1h' });
-        res.json({ status: 'success', token });
+        res.json({ status: 'success', token, userId: user.id });
     } catch (err) {
         res.status(500).json({ status: 'error', message: '서버 오류', error: err.message });
     }

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -36,9 +36,11 @@ export default function LoginPage() {
 
       // 백엔드에서 status='success'와 token을 함께 보내준다고 가정
       if (response.data.status === "success") {
-        // 토큰 로컬 저장
+        // 토큰 및 사용자 ID 저장
         localStorage.setItem("token", response.data.token);
-        localStorage.setItem("userId", data.email);
+        if (response.data.userId) {
+          localStorage.setItem("userId", String(response.data.userId));
+        }
         // 페이지 이동
         navigate("/");
       } else {

--- a/frontend/src/pages/notices/NoticeCreatePage.tsx
+++ b/frontend/src/pages/notices/NoticeCreatePage.tsx
@@ -12,17 +12,22 @@ export default function NoticeCreatePage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      const userId = localStorage.getItem("userId"); // ✅ 숫자로 변환
-      console.log(userId);
-      if (userId == null || userId == '' ) {
+      const userIdStr = localStorage.getItem("userId");
+      if (!userIdStr) {
         setError("로그인이 필요합니다.");
         return;
       }
-  
+
+      const userId = parseInt(userIdStr, 10);
+      if (isNaN(userId)) {
+        setError("잘못된 사용자 정보입니다.");
+        return;
+      }
+
       await axios.post("http://localhost:5000/api/notices", {
         title,
         content,
-        created_by: 4, // ✅ 올바른 ID 전달
+        created_by: userId,
       });
   
       navigate("/notices");


### PR DESCRIPTION
## Summary
- return `userId` from the backend login route
- persist the backend-provided `userId` on login
- use stored `userId` when creating new notices

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6847a81987a88333bb48a1ff66ba9d65